### PR TITLE
Added a new resource regarding the 6502 CPU under the Commodore 64 subtitle.

### DIFF
--- a/emudev_resources_systems.md
+++ b/emudev_resources_systems.md
@@ -315,6 +315,7 @@ There are no "full" tutorials for other systems, so using references will be a b
 ## Commodore 64
 - See 6502 resources in the [65xx family section](#65xx-family) (the C64 uses a 6510)
 - [MCS6500 family programming manual](http://archive.6502.org/books/mcs6500_family_programming_manual.pdf) (doesn't respond to https://)
+- Summary of single-cycle execution with the [6502 addressing modes](https://xotmatrix.github.io/6502/6502-single-cycle-execution.html)
 - [C64 wiki](https://www.c64-wiki.com)
 - [VICE test ROMs](https://vice-emu.pokefinder.org/index.php/Testbench)
 - [SID manual](http://archive.6502.org/datasheets/mos_6581_sid.pdf) (doesn't respond to https://)


### PR DESCRIPTION
Added a resource that explains every cycle of every **6502** for addressing mode for operations _Read_, _Write_ and _RMW_. The resource or link has been added under the **Commodore 64** subtitle.