### PR TITLE
Fix some dead emulator101 links and add SSTs for gameboy

### DIFF
--- a/emudev_resources_general.md
+++ b/emudev_resources_general.md
@@ -2,7 +2,7 @@
 
 - **Overview of emulation development: <https://stackoverflow.com/a/448689>**
 - **Architecture overview of various consoles: <https://copetti.org/projects/consoles>**
-- An introduction: <[http://www.emulator101.com](https://web.archive.org/web/20241010195903/http://www.emulator101.com/)>
+- An introduction: [http://www.emulator101.com](https://web.archive.org/web/20241010195903/http://www.emulator101.com/)
 - Docs for various systems: <https://github.com/shonumi/Emu-Docs> (combine with resources below)
 - Emulation blogs: <https://dolphin-emu.org/blog>, [[archived] byuu.net/](https://web.archive.org/web/20201221154920/https://byuu.net/), <http://emudev.de>, [[archived] noxa.org/emulation/](https://web.archive.org/web/20220928023912/http://www.noxa.org/blog/category/coding/emulation/), <http://melonds.kuribo64.net/>, <https://pcsx2.net/blog/tags/devblog>, <https://shonumi.github.io/articles.html>, etc
 - Subreddit: <https://www.reddit.com/r/EmuDev>

--- a/emudev_resources_systems.md
+++ b/emudev_resources_systems.md
@@ -85,6 +85,7 @@ There are no "full" tutorials for other systems, so using references will be a b
 - [Notes by GhostSonic on GB sound emulation](https://www.reddit.com/r/EmuDev/comments/5gkwi5/gb_apu_sound_emulation/dat3zni)
 - [Explanation of binary-coded decimals and the DAA instruction](https://ehaskins.com/2018-01-30%20Z80%20DAA)
 - [Guide to the half-carry flag](https://robdor.com/2016/08/10/gameboy-emulator-half-carry-flag)
+- [Single step tests](https://github.com/SingleStepTests/sm83)
 
 ## Game Boy Advance
 - See relevant ARM resources below (the ARM7TDMI used in the GBA implements ARMv4T)
@@ -430,7 +431,7 @@ There are no "full" tutorials for other systems, so using references will be a b
 
 ## Multiple systems
 - <https://www.zophar.net/documents.html>
-- <http://www.emulator101.com>
+- [http://www.emulator101.com](https://web.archive.org/web/20241010195903/http://www.emulator101.com/)
 - <http://hitmen.c02.at/index.html>
 - <http://www.codeslinger.co.uk> (doesn't respond to https://, disable extensions such as HTTPS Everywhere if it doesn't load)
 - <https://emudev.de>
@@ -448,7 +449,7 @@ There are no "full" tutorials for other systems, so using references will be a b
 - [6502 decimal mode](https://www.atarimagazines.com/compute/issue50/268_1_MACHINE_LANGUAGE.php)
 
 ## 8080
-- [8080 tutorial (among other things)](http://www.emulator101.com)
+- [8080 tutorial (among other things)](https://web.archive.org/web/20241010195903/http://www.emulator101.com/)
 - [Assembly programming manual](https://altairclone.com/downloads/manuals/8080%20Programmers%20Manual.pdf)
 - [Datasheet](https://altairclone.com/downloads/manuals/8080%20Data%20Sheet.pdf)
 - [Instruction table](https://tobiasvl.github.io/optable/intel-8080/classic)


### PR DESCRIPTION
Some emulator101 links still go to the original, now dead site. I also added some Single Step tests for the gameboy as it could be a useful resource to test opcode accuracy before anything is implemented

The "Decoding GB Instructions algorithmically" link doesnt seem to work as it needs some sort of token in order to access it