### PR TITLE
Remove Itanium architecture documentation links

### DIFF
--- a/emudev_resources_systems.md
+++ b/emudev_resources_systems.md
@@ -518,13 +518,6 @@ There are no "full" tutorials for other systems, so using references will be a b
 - [IDT R30xx Family Software Reference Manual](https://cgi.cse.unsw.edu.au/~cs3231/doc/R3000.pdf) (PS1 CPU, PS2 IOP)
 - [VR43xx CPU manual](http://datasheets.chipdb.org/NEC/Vr-Series/Vr43xx/U10504EJ7V0UMJ1.pdf) (Nintendo 64)
 
-## Itanium
-- [Itanium Architecture Software Developer's Manual](https://cdn.discordapp.com/attachments/698838582181363752/805813408309837904/itanium-architecture-vol-1-2-3-4-reference-set-manual.pdf) ([original](https://www.intel.com/content/dam/doc/manual/itanium-architecture-vol-1-2-3-4-reference-set-manual.pdf))
-- [Itanium System Abstraction Layer Specification](https://cdn.discordapp.com/attachments/698838582181363752/805813867694653500/itanium-system-abstraction-layer-specification.pdf) ([original](https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/itanium-system-abstraction-layer-specification.pdf))
-- [460GX Chipset Developer's Manual](https://cdn.discordapp.com/attachments/698838582181363752/805814367097716766/460gx.pdf) ([original](https://www.manualslib.com/manual/77665/Intel-460gx.html))
-- [Intel® E8870IO Server I/O Hub Datasheet](https://cdn.discordapp.com/attachments/698838582181363752/805814970977747015/e8870io-server-io-hub-datasheet.pdf) ([original](https://www.intel.com/content/dam/doc/datasheet/e8870io-server-io-hub-datasheet.pdf))
-- [Intel® E8870 SNC Datasheet](https://cdn.discordapp.com/attachments/698838582181363752/805815757861945344/e8870-snc-datasheet.pdf) ([original](https://pccomponents.com/datasheets/INTEL-251112.PDF))
-
 **Contributing**
 
 Have something to add to this list? Submit a pull request [here](https://github.com/emudev-org/discord-resources/blob/main/emudev_resources_systems.md).


### PR DESCRIPTION
okay this is a bit of a bold move but let's be real. who the hell is  going to do Itanium emulation?

even if someone did Itanium emulation they can google for the data sheets

..also all the discord cdn links are dead so there's that too